### PR TITLE
Update GCS backup buckets

### DIFF
--- a/mainnet/backups/gcs.yaml
+++ b/mainnet/backups/gcs.yaml
@@ -1,6 +1,6 @@
 env_vars:
 - key: BUCKET
-  value: aptos-mainnet-backup-backup-e098483d
+  value: aptos-mainnet-backup
 - key: SUB_DIR
   value: e1
 commands:

--- a/testnet/backups/gcs.yaml
+++ b/testnet/backups/gcs.yaml
@@ -1,6 +1,6 @@
 env_vars:
 - key: BUCKET
-  value: aptos-testnet-backup-b7b1ad7a
+  value: aptos-testnet-backup
 - key: SUB_DIR
   value: e1
 commands:


### PR DESCRIPTION
Use the new backup buckets that are used by the platform PFN backups.