### PR TITLE
Exclude LFS files from default fetch to speed up clones

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,2 @@
+[lfs]
+	fetchexclude = *

--- a/README.md
+++ b/README.md
@@ -4,3 +4,15 @@
 - `ait3/`: Aptos Incentivized Testnet 3, short lived testing network.
 - `testnet/`: Aptos stable testnet, data will be persisted during upgrades. 
 - `mainnet/`: Aptos Mainnet
+
+## Fetching LFS files
+
+Large binaries (e.g. `digest_key.bin`, `pp.bin`) are stored in Git LFS but excluded from default fetches to keep clones fast. After cloning, pull only the network you need:
+
+```bash
+git lfs pull --include="devnet/*"
+# or
+git lfs pull --include="testnet/*"
+```
+
+To fetch everything: `git lfs pull --include="*"`.


### PR DESCRIPTION
## Summary
- Adds `.lfsconfig` with `fetchexclude = *` so `git clone` only pulls LFS pointers, not the ~3.9 GB of binaries in `devnet/` and `testnet/`.
- Documents the explicit `git lfs pull --include=...` workflow in the README.
- Tamper evidence is unchanged: pointer files (SHA256 of content) are still committed and verified when LFS bytes are pulled.

## Test plan
- [x] Fresh clone completes without downloading LFS binaries (`du -sh .git/lfs` should be ~0)
- [x] `git lfs pull --include="devnet/*"` materializes `devnet/digest_key.bin` and `devnet/pp.bin`
- [x] `git lfs pull --include="*"` still fetches everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)