### PR TITLE
[ci] Require release bundle sign-offs

### DIFF
--- a/.github/scripts/detect_changed_bundles.py
+++ b/.github/scripts/detect_changed_bundles.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Detect release bundle directories (framework-releases/<version>/) touched by a PR.
+
+Used by the detect-bundle-changes job in
+.github/workflows/verify-release-bundles.yaml. Must run inside a checkout of
+the PR's merge result, with full history fetched.
+
+Reads from the environment:
+  BASE_SHA / HEAD_SHA: the PR's base and head commits. The diff uses
+      BASE...HEAD (merge-base), so a stale PR is not blamed for bundles that
+      landed on the base branch after it diverged.
+
+Emits GitHub Actions step outputs (appended to $GITHUB_OUTPUT, or printed to
+stdout when run locally):
+  any:     "true" if at least one touched bundle still exists in the merge
+           result (a directory absent from it was deleted by the PR; there is
+           nothing left to verify)
+  bundles: the touched bundle directory names, space-separated, sorted
+
+Fails (exit 1) on a file sitting directly under framework-releases/ (bundles
+are directories), or on a bundle directory name outside the allowed character
+set.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+BUNDLE_BASE = "framework-releases"
+
+NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def fail(message: str) -> None:
+    print(f"::error::{message}")
+    sys.exit(1)
+
+
+def write_output(key: str, value: str) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as f:
+            f.write(f"{key}={value}\n")
+    else:
+        sys.stdout.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    base = os.environ["BASE_SHA"]
+    head = os.environ["HEAD_SHA"]
+
+    # -z: NUL-separated, unquoted paths, so unusual file names arrive verbatim.
+    diff = subprocess.run(
+        ["git", "diff", "--name-only", "-z", f"{base}...{head}", "--", f"{BUNDLE_BASE}/"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    paths = [p for p in diff.stdout.split("\0") if p]
+
+    dirs = set()
+    for path in paths:
+        rest = path[len(BUNDLE_BASE) + 1 :]
+        name, sep, _ = rest.partition("/")
+        if not sep:
+            fail(
+                f"stray file directly under {BUNDLE_BASE}/: {path};"
+                f" bundles are directories ({BUNDLE_BASE}/<version>/...)"
+            )
+        if not NAME_RE.match(name):
+            fail(f"bundle directory name {name!r} contains unsupported characters")
+        dirs.add(name)
+
+    existing = []
+    for name in sorted(dirs):
+        if os.path.isdir(os.path.join(BUNDLE_BASE, name)):
+            existing.append(name)
+        else:
+            print(f"bundle '{name}' is deleted by this PR; nothing to verify")
+
+    write_output("any", "true" if existing else "false")
+    write_output("bundles", " ".join(existing))
+    print(f"changed bundles: {' '.join(existing) or 'none'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/verify_bundles.py
+++ b/.github/scripts/verify_bundles.py
@@ -23,11 +23,11 @@ import sys
 TOOL = os.environ.get("RELEASE_TOOL", "target/release/aptos-release-tool")
 NETWORKS_ROOT = os.environ.get("NETWORKS_ROOT", "aptos-networks")
 
-def summary(line: str) -> None:
+def write_summary(lines: list[str]) -> None:
     step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if step_summary:
         with open(step_summary, "a") as f:
-            f.write(line + "\n")
+            f.write("\n".join(lines) + "\n")
 
 
 def main() -> int:
@@ -36,11 +36,7 @@ def main() -> int:
         print("no bundles to verify")
         return 0
 
-    summary("## Release bundle verification")
-    summary("")
-    summary("| Bundle | Result |")
-    summary("|---|---|")
-
+    summary = ["## Release bundle verification", "", "| Bundle | Result |", "|---|---|"]
     failed = []
     for name in bundles:
         bundle_dir = os.path.join(NETWORKS_ROOT, "framework-releases", name)
@@ -49,12 +45,13 @@ def main() -> int:
         print("::endgroup::", flush=True)
 
         if result.returncode == 0:
-            summary(f"| `{name}` | ✅ verified, signed off |")
+            summary.append(f"| `{name}` | ✅ verified, signed off |")
         else:
-            summary(f"| `{name}` | ❌ failed |")
+            summary.append(f"| `{name}` | ❌ failed |")
             print(f"::error::verify-bundle --require-signoff failed for framework-releases/{name}")
             failed.append(name)
 
+    write_summary(summary)
     if failed:
         print(f"failed bundles: {' '.join(failed)}")
         return 1

--- a/.github/scripts/verify_bundles.py
+++ b/.github/scripts/verify_bundles.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Verify each touched release bundle: integrity plus full sign-off.
+
+Used by the verify-release-bundles job in .github/workflows/verify-release-bundles.yaml.
+
+Reads from the environment:
+  BUNDLES:      space-separated bundle directory names, as emitted by
+                detect_changed_bundles.py
+  RELEASE_TOOL: path to the aptos-release-tool binary
+                (default: target/release/aptos-release-tool)
+  NETWORKS_ROOT: path to the aptos-networks checkout containing
+                framework-releases/ (default: aptos-networks)
+
+Exits non-zero if any bundle fails; all bundles are verified and reported
+before exiting. Appends a per-bundle result table to $GITHUB_STEP_SUMMARY
+when set.
+"""
+
+import os
+import subprocess
+import sys
+
+TOOL = os.environ.get("RELEASE_TOOL", "target/release/aptos-release-tool")
+NETWORKS_ROOT = os.environ.get("NETWORKS_ROOT", "aptos-networks")
+
+def summary(line: str) -> None:
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a") as f:
+            f.write(line + "\n")
+
+
+def main() -> int:
+    bundles = os.environ.get("BUNDLES", "").split()
+    if not bundles:
+        print("no bundles to verify")
+        return 0
+
+    summary("## Release bundle verification")
+    summary("")
+    summary("| Bundle | Result |")
+    summary("|---|---|")
+
+    failed = []
+    for name in bundles:
+        bundle_dir = os.path.join(NETWORKS_ROOT, "framework-releases", name)
+        print(f"::group::verify-bundle {bundle_dir}", flush=True)
+        result = subprocess.run([TOOL, "verify-bundle", "--bundle", bundle_dir, "--require-signoff"])
+        print("::endgroup::", flush=True)
+
+        if result.returncode == 0:
+            summary(f"| `{name}` | ✅ verified, signed off |")
+        else:
+            summary(f"| `{name}` | ❌ failed |")
+            print(f"::error::verify-bundle --require-signoff failed for framework-releases/{name}")
+            failed.append(name)
+
+    if failed:
+        print(f"failed bundles: {' '.join(failed)}")
+        return 1
+    print(f"all {len(bundles)} bundle(s) verified and signed off")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/verify-release-bundles.yaml
+++ b/.github/workflows/verify-release-bundles.yaml
@@ -1,0 +1,67 @@
+# Blocking CI for release bundles (framework-releases/<version>/), to mandate
+# sign-offs (all checkboxes ticked in summaries) before merging.
+
+name: "Require Release Bundle Sign-Offs"
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-release-bundles-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  detect-bundle-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      any: ${{ steps.detect.outputs.any }}
+      bundles: ${{ steps.detect.outputs.bundles }}
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so the base...head diff works regardless of PR age.
+          fetch-depth: 0
+
+      - name: Detect changed bundles
+        id: detect
+        run: python3 .github/scripts/detect_changed_bundles.py
+
+  verify-release-bundles:
+    needs: detect-bundle-changes
+    # Skipped (= passing, for required status checks) unless the PR touches a
+    # bundle. `always()` is not wanted here: if detect fails, this job must
+    # not silently pass, and detect's own failure already blocks the PR.
+    if: needs.detect-bundle-changes.outputs.any == 'true'
+    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu22-x64,run-id=${{ github.run_id }}
+    env:
+      BUNDLES: ${{ needs.detect-bundle-changes.outputs.bundles }}
+    steps:
+      - name: Checkout aptos-core
+        uses: actions/checkout@v6
+        with:
+          repository: aptos-labs/aptos-core
+          ref: main
+
+      # Nested inside the aptos-core checkout; must run after it, since
+      # checking out into the workspace root deletes existing contents.
+      - name: Checkout the PR
+        uses: actions/checkout@v6
+        with:
+          path: aptos-networks
+
+      - name: Rust setup
+        uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+        with:
+          ADDITIONAL_KEY: verify-release-bundles
+
+      - name: Build aptos-release-tool
+        run: cargo build --release -p aptos-release-tool
+
+      - name: Verify bundles (integrity + sign-off)
+        run: python3 aptos-networks/.github/scripts/verify_bundles.py


### PR DESCRIPTION
## Summary

Adds a CI check for PRs that add or modify release bundles under `framework-releases/` (opened by the `generate-release-bundle` workflow in internal-ops):

- A cheap `detect-bundle-changes` job runs on every PR and lists the touched bundle directories.
- When a PR touches bundles, `verify-release-bundles` builds `aptos-release-tool` from aptos-core main and runs `verify-bundle --require-signoff` on each: full integrity (checksums, digest, layout) plus **every sign-off checkbox in `summary/` ticked**. Ticking boxes is checksum-neutral, so the review flow is: bot opens the bundle PR (check is red), reviewers read `summary/` and tick the boxes, check goes green.

To make it blocking after merge: add `detect-bundle-changes` and `verify-release-bundles` as required status checks on `main`. The verify job skips itself on non-bundle PRs, which required checks treat as passing.

## Test Plan

Scripts tested locally: 8-case matrix for detection (add/modify/delete, stray files, unsafe names) and stub-tool runs for the verify loop (partial failure, empty input, step summary output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)